### PR TITLE
Fix Windows incompatibility style

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -46,8 +46,9 @@ html, body {
 }
 
 #popup .m-select {
-  width: 310px;
-  margin: 20px 0 0 0;
+  width: 100%;
+  min-width: 310px;
+  margin-top: 20px;
 }
 
 

--- a/css/popup.css
+++ b/css/popup.css
@@ -11,7 +11,6 @@ html, body {
 
 #popup {
   letter-spacing: 0.2px;
-  width: 350px;
   padding: 20px;
   -webkit-user-select: none;
 }
@@ -47,7 +46,7 @@ html, body {
 }
 
 #popup .m-select {
-  width: 350px;
+  width: 310px;
   margin: 20px 0 0 0;
 }
 


### PR DESCRIPTION
Fix bug (#78) on the popup when it opened from the menu overflow.
I make some tests on Firefox (Windows 10) and Chrome (Windows 10), it seems to be fix.