### PR TITLE
Indent headers based on level

### DIFF
--- a/content/index.js
+++ b/content/index.js
@@ -179,25 +179,10 @@ var toc = (
     level: parseInt(node.tagName.replace('H', '')),
     title: node.innerText
   }))
-  .reduce((html, header, index, headers) => {
-    if (index) {
-      var prev = headers[index - 1]
-    }
-    if (!index || prev.level === header.level) {
-      html += link(header)
-    }
-    else if (prev.level > header.level) {
-      while (prev.level-- > header.level) {
-        html += '</div>'
-      }
-      html += link(header)
-    }
-    else if (prev.level < header.level) {
-      while (prev.level++ < header.level) {
-        html += '<div id="_ul">'
-      }
-      html += link(header)
-    }
+  .reduce((html, header) => {
+    html += '<div id="_ul">'.repeat(header.level)
+    html += link(header)
+    html += '</div>'.repeat(header.level)
     return html
   }, '<div id="_toc"><div id="_ul">') + '</div></div>'
 


### PR DESCRIPTION
Fixes an error that would occur when the first header is not at the highest level.

Previously, when the first header is not at the highest level (as in the markdown below), there would be too many closing `</div>` tags. This pr simply uses the appropriate number of `<div>` tags for each header based on its level.

```markdown
## Header 1
# Header 2
```