### PR TITLE
update mathjax config, support more math symbols

### DIFF
--- a/content/index.js
+++ b/content/index.js
@@ -280,6 +280,7 @@ var mathjax = `
         'AMSsymbols.js',
         'noErrors.js',
         'noUndefined.js',
+        'mediawiki-texvc.js',
       ]
     },
     tex2jax: {


### PR DESCRIPTION
Support more math symbols like plus-minus(±): `\plusmn`. 
Ref: http://docs.mathjax.org/en/v2.7-latest/tex.html#mediawiki-texvc