### PR TITLE
fix scroll.js bug when headers are numbers

### DIFF
--- a/content/scroll.js
+++ b/content/scroll.js
@@ -105,8 +105,8 @@ var scroll = (() => {
         html.scrollTop ? (html.scrollTop = 0, html) : $('body')
       ))()
 
-      if (!update && location.hash && $(location.hash)) {
-        get(container, 'md-', $(location.hash).offsetTop)
+      if (!update && location.hash && document.getElementById(location.hash.slice(1))) {
+        get(container, 'md-', document.getElementById(location.hash.slice(1)).offsetTop)
       }
       else {
         get(container, 'md-')


### PR DESCRIPTION
I have a book where headers are just chapter numbers.
And toc links look like `<a href="#1">1</a>`
And when you visit `book.md#1` `scroll.js` throws `'#1' is not a valid selector.`

This pr fixes this.