### PR TITLE
added grid-table plugin

### DIFF
--- a/background/compilers/markdown-it.js
+++ b/background/compilers/markdown-it.js
@@ -16,6 +16,7 @@ md.compilers['markdown-it'] = (() => {
     cjk: false,
     deflist: false,
     footnote: false,
+    gridTableRulePlugin: false,
     ins: false,
     mark: false,
     sub: false,
@@ -35,6 +36,7 @@ md.compilers['markdown-it'] = (() => {
     cjk: 'Suppress linebreaks between east asian characters',
     deflist: 'Definition list <dl>\ntitle\n: definition',
     footnote: 'Footnotes\nword[^1]\n[^1]: text',
+    gridTableRulePlugin: 'support for pandoc grid_tables',
     ins: 'Inserted text <ins>\n++text++',
     mark: 'Marked text <mark>\n==text==',
     sub: 'Subscript <sub>\n~text~',
@@ -55,6 +57,7 @@ md.compilers['markdown-it'] = (() => {
         .use(state['markdown-it'].cjk ? mdit.cjk : () => {})
         .use(state['markdown-it'].deflist ? mdit.deflist : () => {})
         .use(state['markdown-it'].footnote ? mdit.footnote : () => {})
+        .use(state['markdown-it'].gridTableRulePlugin ? mdit.gridTableRulePlugin : () => {})
         .use(state['markdown-it'].ins ? mdit.ins : () => {})
         .use(state['markdown-it'].mark ? mdit.mark : () => {})
         .use(state['markdown-it'].sub ? mdit.sub : () => {})

--- a/background/storage.js
+++ b/background/storage.js
@@ -168,6 +168,7 @@ md.storage.migrations = (state) => {
       cjk: false,
       deflist: false,
       footnote: false,
+      gridTableRulePlugin: false,
       ins: false,
       mark: false,
       sub: false,

--- a/build/README.md
+++ b/build/README.md
@@ -37,6 +37,7 @@ sh build/package.sh
 | markdown-it-cjk-breaks | 1.1.3
 | markdown-it-deflist    | 2.1.0
 | markdown-it-footnote   | 3.0.3
+| markdown-it-gridtables | 0.4.0
 | markdown-it-ins        | 3.0.1
 | markdown-it-mark       | 3.0.1
 | markdown-it-sub        | 1.0.0

--- a/build/markdown-it/markdown-it.mjs
+++ b/build/markdown-it/markdown-it.mjs
@@ -6,6 +6,7 @@ import attrs from 'markdown-it-attrs'
 import cjk from 'markdown-it-cjk-breaks'
 import deflist from 'markdown-it-deflist'
 import footnote from 'markdown-it-footnote'
+import gridTableRulePlugin from 'markdown-it-gridtables'
 import ins from 'markdown-it-ins'
 import mark from 'markdown-it-mark'
 import sub from 'markdown-it-sub'
@@ -21,6 +22,7 @@ export {
   cjk,
   deflist,
   footnote,
+  gridTableRulePlugin,
   ins,
   mark,
   sub,

--- a/build/markdown-it/package.json
+++ b/build/markdown-it/package.json
@@ -12,6 +12,7 @@
     "markdown-it-cjk-breaks": "1.1.3",
     "markdown-it-deflist": "2.1.0",
     "markdown-it-footnote": "3.0.3",
+    "markdown-it-gridtables": "0.4.0",
     "markdown-it-ins": "3.0.1",
     "markdown-it-mark": "3.0.1",
     "markdown-it-sub": "1.0.0",


### PR DESCRIPTION
I added support for [this markdown-it plugin](https://github.com/basverweij/markdown-it-gridtables?tab=readme-ov-file) that process [pandoc-style grid tables](https://pandoc.org/MANUAL.html#tables).

Known issue: mathjax does not seem to play nicely with this, which was unfortunately exactly the use case I wanted this for, but I still think this could be useful.