### PR TITLE
Show a Copy button when hovering over a code block to copy to clipboard

### DIFF
--- a/background/inject.js
+++ b/background/inject.js
@@ -1,4 +1,3 @@
-
 md.inject = ({storage: {state}}) => (id) => {
 
   chrome.scripting.executeScript({
@@ -24,14 +23,16 @@ md.inject = ({storage: {state}}) => (id) => {
     files: [
       '/content/index.css',
       '/content/themes.css',
-    ]
+      state.content.syntax && '/vendor/prism-toolbar.min.css'
+    ].filter(Boolean).flat()
   })
 
   chrome.scripting.executeScript({
     target: {tabId: id},
     files: [
       '/vendor/mithril.min.js',
-      state.content.syntax && ['/vendor/prism.min.js', '/vendor/prism-autoloader.min.js', '/content/prism.js'],
+      state.content.syntax && ['/vendor/prism.min.js', '/vendor/prism-autoloader.min.js',
+        'vendor/prism-toolbar.min.js', 'vendor/prism-copy-to-clipboard.min.js', '/content/prism.js'],
       state.content.emoji && '/content/emoji.js',
       state.content.mermaid && ['/vendor/mermaid.min.js', '/vendor/panzoom.min.js', '/content/mermaid.js'],
       state.content.mathjax && ['/content/mathjax.js', '/vendor/mathjax/tex-mml-chtml.js'],

--- a/build/prism/build.sh
+++ b/build/prism/build.sh
@@ -18,6 +18,12 @@ node fix-autoloader.js \
   tmp/prism-autoloader.js
 npx terser --compress --mangle -- tmp/prism-autoloader.js > tmp/prism-autoloader.min.js
 
+# prism-toolbar.min.js
+cp node_modules/prismjs/plugins/toolbar/prism-toolbar.min.js tmp/prism-toolbar.min.js
+
+# prism-copy-to-clipboard.min.js
+cp node_modules/prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js tmp/prism-copy-to-clipboard.min.js
+
 # prism.min.css
 # prism-okaidia.min.css
 npx csso --input node_modules/prismjs/themes/prism.css --output tmp/prism.min.css
@@ -26,11 +32,19 @@ node fix-themes.js \
   tmp/prism.min.css \
   tmp/prism-okaidia.min.css
 
+# prism-toolbar.min.css
+cp node_modules/prismjs/plugins/toolbar/prism-toolbar.min.css tmp/prism-toolbar.min.css
+
 # copy
 cp tmp/prism.min.js ../../vendor/
 cp tmp/prism-autoloader.min.js ../../vendor/
 cp tmp/prism.min.css ../../vendor/
 cp tmp/prism-okaidia.min.css ../../vendor/
+
+cp tmp/prism-toolbar.min.js ../../vendor
+cp tmp/prism-toolbar.min.css ../../vendor
+cp tmp/prism-copy-to-clipboard.min.js ../../vendor
+
 # languages
 mkdir -p ../../vendor/prism/
 cp node_modules/prismjs/components/prism-*.min.js ../../vendor/prism/

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -45,7 +45,8 @@
         "/themes/*",
         "/vendor/mathjax/fonts/*",
         "/vendor/prism.min.css",
-        "/vendor/prism-okaidia.min.css"
+        "/vendor/prism-okaidia.min.css",
+        "/vendor/prism-toolbar.min.css"
       ]
     }
   ],

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -67,7 +67,8 @@
         "/themes/*",
         "/vendor/mathjax/fonts/*",
         "/vendor/prism.min.css",
-        "/vendor/prism-okaidia.min.css"
+        "/vendor/prism-okaidia.min.css",
+        "/vendor/prism-toolbar.min.css"
       ]
     }
   ],


### PR DESCRIPTION
This change adds  the [copy to clipboard Prism plugin](https://prismjs.com/plugins/copy-to-clipboard/) which shows a **Copy** button when hovering over a code block when the `Syntax` option is enabled to syntax highlight code blocks.  Clicking on the button copies the code block to the clipboard.

Addresses this [feature request #60](https://github.com/simov/markdown-viewer/issues/60).

See attached screenshot for an example:

![CopyButton](https://github.com/simov/markdown-viewer/assets/4666142/e02460ba-e254-4f87-8ec6-d2c478d78914)

