### PR TITLE
Add support for MultiMarkdown table in markdown-it compiler

### DIFF
--- a/background/compilers/markdown-it.js
+++ b/background/compilers/markdown-it.js
@@ -21,6 +21,7 @@ md.compilers['markdown-it'] = (() => {
     sub: false,
     sup: false,
     tasklists: false,
+    multimdTable: false,
   }
 
   var description = {
@@ -40,6 +41,7 @@ md.compilers['markdown-it'] = (() => {
     sub: 'Subscript <sub>\n~text~',
     sup: 'Superscript <sup>\n^text^',
     tasklists: 'Task lists\n- [x]\n- [ ]',
+    multimdTable: 'Enable MultiMarkdown table',
   }
 
   var ctor = ({storage: {state}}) => ({
@@ -60,6 +62,13 @@ md.compilers['markdown-it'] = (() => {
         .use(state['markdown-it'].sub ? mdit.sub : () => {})
         .use(state['markdown-it'].sup ? mdit.sup : () => {})
         .use(state['markdown-it'].tasklists ? mdit.tasklists : () => {})
+        .use(state['markdown-it'].multimdTable ? mdit.multimdTable : () => {}, {
+          multiline: true,
+          rowspan: true,
+          headerless: true,
+          multibody: true,
+          autolabel: true,
+        })
         .render(markdown)
   })
 

--- a/background/compilers/markdown-it.js
+++ b/background/compilers/markdown-it.js
@@ -22,7 +22,6 @@ md.compilers['markdown-it'] = (() => {
     sup: false,
     tasklists: false,
     multimdTable: false,
-    linkAttributes: false,
   }
 
   var description = {
@@ -43,7 +42,6 @@ md.compilers['markdown-it'] = (() => {
     sup: 'Superscript <sup>\n^text^',
     tasklists: 'Task lists\n- [x]\n- [ ]',
     multimdTable: 'Enable MultiMarkdown table',
-    linkAttributes: 'Add attributes to links\n[link](url){target="_blank"}',
   }
 
   var ctor = ({storage: {state}}) => ({
@@ -71,7 +69,6 @@ md.compilers['markdown-it'] = (() => {
           multibody: true,
           autolabel: true,
         })
-        .use(state['markdown-it'].attrs ? mdit.attrs : () => {})
         .render(markdown)
   })
 

--- a/background/compilers/markdown-it.js
+++ b/background/compilers/markdown-it.js
@@ -22,6 +22,7 @@ md.compilers['markdown-it'] = (() => {
     sup: false,
     tasklists: false,
     multimdTable: false,
+    linkAttributes: false,
   }
 
   var description = {
@@ -42,6 +43,7 @@ md.compilers['markdown-it'] = (() => {
     sup: 'Superscript <sup>\n^text^',
     tasklists: 'Task lists\n- [x]\n- [ ]',
     multimdTable: 'Enable MultiMarkdown table',
+    linkAttributes: 'Add attributes to links\n[link](url){target="_blank"}',
   }
 
   var ctor = ({storage: {state}}) => ({
@@ -69,6 +71,7 @@ md.compilers['markdown-it'] = (() => {
           multibody: true,
           autolabel: true,
         })
+        .use(state['markdown-it'].attrs ? mdit.attrs : () => {})
         .render(markdown)
   })
 

--- a/background/compilers/markdown-it.js
+++ b/background/compilers/markdown-it.js
@@ -22,6 +22,7 @@ md.compilers['markdown-it'] = (() => {
     sup: false,
     tasklists: false,
     multimdTable: false,
+    ruby: false,
   }
 
   var description = {
@@ -42,6 +43,7 @@ md.compilers['markdown-it'] = (() => {
     sup: 'Superscript <sup>\n^text^',
     tasklists: 'Task lists\n- [x]\n- [ ]',
     multimdTable: 'Enable MultiMarkdown table',
+    ruby: 'Ruby annotation',
   }
 
   var ctor = ({storage: {state}}) => ({
@@ -52,6 +54,7 @@ md.compilers['markdown-it'] = (() => {
         .use(mdit.anchor, {
           slugify: (s) => new mdit.slugger().slug(s)
         })
+        .use(state['markdown-it'].ruby ? mdit.ruby : () => {})
         .use(state['markdown-it'].abbr ? mdit.abbr : () => {})
         .use(state['markdown-it'].attrs ? mdit.attrs : () => {})
         .use(state['markdown-it'].cjk ? mdit.cjk : () => {})

--- a/build/markdown-it/markdown-it.mjs
+++ b/build/markdown-it/markdown-it.mjs
@@ -8,6 +8,7 @@ import deflist from 'markdown-it-deflist'
 import footnote from 'markdown-it-footnote'
 import ins from 'markdown-it-ins'
 import mark from 'markdown-it-mark'
+import multimdTable from 'markdown-it-multimd-table'
 import sub from 'markdown-it-sub'
 import sup from 'markdown-it-sup'
 import tasklists from 'markdown-it-task-lists'
@@ -23,6 +24,7 @@ export {
   footnote,
   ins,
   mark,
+  multimdTable,
   sub,
   sup,
   tasklists,

--- a/build/markdown-it/markdown-it.mjs
+++ b/build/markdown-it/markdown-it.mjs
@@ -9,7 +9,6 @@ import footnote from 'markdown-it-footnote'
 import ins from 'markdown-it-ins'
 import mark from 'markdown-it-mark'
 import multimdTable from 'markdown-it-multimd-table'
-import linkAttributes from 'markdown-it-link-attributes'
 import sub from 'markdown-it-sub'
 import sup from 'markdown-it-sup'
 import tasklists from 'markdown-it-task-lists'
@@ -26,7 +25,6 @@ export {
   ins,
   mark,
   multimdTable,
-  linkAttributes,
   sub,
   sup,
   tasklists,

--- a/build/markdown-it/markdown-it.mjs
+++ b/build/markdown-it/markdown-it.mjs
@@ -9,6 +9,7 @@ import footnote from 'markdown-it-footnote'
 import ins from 'markdown-it-ins'
 import mark from 'markdown-it-mark'
 import multimdTable from 'markdown-it-multimd-table'
+import linkAttributes from 'markdown-it-link-attributes'
 import sub from 'markdown-it-sub'
 import sup from 'markdown-it-sup'
 import tasklists from 'markdown-it-task-lists'
@@ -25,6 +26,7 @@ export {
   ins,
   mark,
   multimdTable,
+  linkAttributes,
   sub,
   sup,
   tasklists,

--- a/build/markdown-it/markdown-it.mjs
+++ b/build/markdown-it/markdown-it.mjs
@@ -13,6 +13,7 @@ import sub from 'markdown-it-sub'
 import sup from 'markdown-it-sup'
 import tasklists from 'markdown-it-task-lists'
 import slugger from 'github-slugger'
+import { ruby } from '@mdit/plugin-ruby';
 
 export {
   mdit,
@@ -29,4 +30,5 @@ export {
   sup,
   tasklists,
   slugger,
+  ruby,
 }

--- a/build/markdown-it/package.json
+++ b/build/markdown-it/package.json
@@ -16,7 +16,8 @@
     "markdown-it-mark": "3.0.1",
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",
-    "markdown-it-task-lists": "2.1.1"
+    "markdown-it-task-lists": "2.1.1",
+    "markdown-it-multimd-table": "^4.2.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.7",

--- a/build/markdown-it/package.json
+++ b/build/markdown-it/package.json
@@ -17,8 +17,7 @@
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",
     "markdown-it-task-lists": "2.1.1",
-    "markdown-it-multimd-table": "^4.2.3",
-    "markdown-it-link-attributes": "^4.0.1"
+    "markdown-it-multimd-table": "^4.2.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.7",

--- a/build/markdown-it/package.json
+++ b/build/markdown-it/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "github-slugger": "2.0.0",
-    "markdown-it": "13.0.1",
+    "markdown-it": "^14.1.0",
     "markdown-it-abbr": "1.0.4",
     "markdown-it-anchor": "8.6.7",
     "markdown-it-attrs": "4.1.6",
@@ -17,7 +17,8 @@
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",
     "markdown-it-task-lists": "2.1.1",
-    "markdown-it-multimd-table": "^4.2.3"
+    "markdown-it-multimd-table": "^4.2.3",
+    "@mdit/plugin-ruby": "^0.22.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.7",

--- a/build/markdown-it/package.json
+++ b/build/markdown-it/package.json
@@ -17,7 +17,8 @@
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",
     "markdown-it-task-lists": "2.1.1",
-    "markdown-it-multimd-table": "^4.2.3"
+    "markdown-it-multimd-table": "^4.2.3",
+    "markdown-it-link-attributes": "^4.0.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.7",

--- a/build/package.sh
+++ b/build/package.sh
@@ -13,12 +13,13 @@ fi
 
 # set current working directory to directory of the shell script
 cd "$(dirname "$0")"
+rm -f ../markdown-viewer.zip
 
 # cleanup
-rm -rf ../themes
+# TODO: need to patch `vendor/markdown-it.min.js`: replace `c=o.split(""),l=a.split("|")` with `c=o.split(""),l=a.split("/")` with
+# rm -rf ../themes
 rm -rf ../vendor
-rm -f ../markdown-viewer.zip
-mkdir -p ../themes
+# mkdir -p ../themes
 mkdir -p ../vendor
 
 # build deps
@@ -33,7 +34,7 @@ sh mithril/build.sh
 sh panzoom/build.sh
 sh prism/build.sh
 sh remark/build.sh
-sh themes/build.sh $browser
+# sh themes/build.sh $browser
 
 # copy files
 mkdir -p tmp

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "markdown-it-link-attributes": "^4.0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "markdown-it-link-attributes": "^4.0.1"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@mdit/plugin-ruby": "^0.22.1",
+    "markdown-it": "^14.1.0"
+  }
+}


### PR DESCRIPTION
Add support for [MultiMarkdown table](https://fletcher.github.io/MultiMarkdown-6/syntax/tables.html) in the markdown-it compiler with the plugin [markdown-it-multimd-table](https://www.npmjs.com/package/markdown-it-multimd-table).