### PR TITLE
Add toggle to display YAML/TOML frontmatter

### DIFF
--- a/background/storage.js
+++ b/background/storage.js
@@ -49,6 +49,7 @@ md.storage.defaults = (compilers) => {
     content: {
       autoreload: false,
       emoji: false,
+      frontmatter: false,
       mathjax: false,
       mermaid: false,
       syntax: true,

--- a/content/index.css
+++ b/content/index.css
@@ -68,6 +68,13 @@ pre#_markdown,
   overflow-y: auto;
 }
 
+.frontmatter pre,
+.frontmatter pre code {
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  overflow-wrap: break-word !important;
+}
+
 @media (max-width: 576px) { /*Extra small - none*/
   .markdown-theme { width: auto !important; }
 }

--- a/content/index.js
+++ b/content/index.js
@@ -117,7 +117,7 @@ var render = (md) => {
   chrome.runtime.sendMessage({
     message: 'markdown',
     compiler: state.compiler,
-    markdown: frontmatter(state.markdown)
+    markdown: frontmatter(state.markdown, state.content.frontmatter)
   }, (res) => {
     state.html = res.html
     if (state.content.emoji) {
@@ -233,18 +233,29 @@ var toc = (() => {
   }
 })()
 
-var frontmatter = (md) => {
-  if (/^-{3}[\s\S]+?-{3}/.test(md)) {
-    var [, yaml] = /^-{3}([\s\S]+?)-{3}/.exec(md)
-    var title = /title: (?:'|")*(.*)(?:'|")*/.exec(yaml)
+var frontmatter = (md, show) => {
+  var yamlMatch = /^(-{3})([\s\S]+?)(-{3})/.exec(md)
+  var tomlMatch = /^(\+{3})([\s\S]+?)(\+{3})/.exec(md)
+
+  if (yamlMatch) {
+    var [full, , content] = yamlMatch
+    var title = /title: (?:'|")*(.*)(?:'|")*/.exec(content)
     title && (document.title = title[1])
+    if (show) {
+      return md.replace(full, '<div class="frontmatter">\n\n```yaml\n' + content.trim() + '\n```\n\n</div>\n\n')
+    }
+    return md.replace(full, '')
   }
-  else if (/^\+{3}[\s\S]+?\+{3}/.test(md)) {
-    var [, toml] = /^\+{3}([\s\S]+?)\+{3}/.exec(md)
-    var title = /title = (?:'|"|`)*(.*)(?:'|"|`)*/.exec(toml)
+  else if (tomlMatch) {
+    var [full, , content] = tomlMatch
+    var title = /title = (?:'|"|`)*(.*)(?:'|"|`)*/.exec(content)
     title && (document.title = title[1])
+    if (show) {
+      return md.replace(full, '<div class="frontmatter">\n\n```toml\n' + content.trim() + '\n```\n\n</div>\n\n')
+    }
+    return md.replace(full, '')
   }
-  return md.replace(/^(?:-|\+){3}[\s\S]+?(?:-|\+){3}/, '')
+  return md
 }
 
 var favicon = () => {

--- a/popup/index.js
+++ b/popup/index.js
@@ -61,6 +61,7 @@ var Popup = () => {
       content: {
         autoreload: 'Auto reload on file change',
         emoji: 'Convert emoji :shortnames: into EmojiOne images',
+        frontmatter: 'Display yaml/toml frontmatter',
         toc: 'Generate Table of Contents',
         mathjax: 'Render MathJax formulas',
         mermaid: 'Mermaid diagrams',


### PR DESCRIPTION
Frontmatter is metadata at the start of markdown files, delimited by `---` (YAML) or `+++` (TOML). It's commonly used by static site generators (Jekyll, Hugo, etc.) for page metadata like title, date, and author. Previously, this extension always stripped frontmatter from the rendered output while extracting the title for the page.

This change adds a "frontmatter" toggle in the Content settings that allows users to optionally display the frontmatter block.

When displayed, frontmatter is wrapped in a `<div class="frontmatter">` containing a fenced code block (```yaml or ```toml). This approach:
- Preserves Prism syntax highlighting for the frontmatter content
- Allows targeting `.frontmatter pre code` with CSS for word wrapping, so long lines wrap instead of causing horizontal scroll
- Keeps other code blocks unaffected (no wrapping)

Title extraction from frontmatter still occurs regardless of whether the frontmatter is displayed.

# Testing
## frontmatter is disabled by default
<img width="2072" height="1588" alt="Screenshot from 2025-11-26 16-17-42" src="https://github.com/user-attachments/assets/acf19348-f3d3-4a85-97e6-2558903a0095" />

## Enabling frontmatter shows the frontmatter in a formatted code block
<img width="2156" height="1590" alt="Screenshot from 2025-11-26 16-17-48" src="https://github.com/user-attachments/assets/0e29011c-1de8-41be-9381-8fa470dde85c" />

## Continues to display after menu is exited
<img width="2091" height="1561" alt="Screenshot from 2025-11-26 16-17-53" src="https://github.com/user-attachments/assets/5aae7239-17b7-46fe-9a97-6405a55803a3" />
