### PR TITLE
fix: allow <br> line breaks in Mermaid node labels

### DIFF
--- a/content/index.css
+++ b/content/index.css
@@ -335,6 +335,15 @@ pre:has(> code.mermaid) {
   height: 100%;
 }
 
+/*fix: allow <br> line breaks inside mermaid node labels
+  The github theme sets `code br { display: none }` which hides <br> inside
+  mermaid `<code>` elements, preventing multi-line node labels from rendering.
+  See: https://github.com/simov/markdown-viewer/issues/263 */
+.markdown-body code.mermaid br,
+.markdown-theme code.mermaid br {
+  display: inline !important;
+}
+
 /*mermaid text bold effect*/
 svg[id^=mermaid] text {
   stroke: none !important;

--- a/content/mermaid.js
+++ b/content/mermaid.js
@@ -5,6 +5,18 @@ var mmd = (() => {
   var walk = (regex, string, result = [], match = regex.exec(string)) =>
     !match ? result : walk(regex, string, result.concat(match[1]))
 
+  var fixMermaidViewBox = () => {
+    document.querySelectorAll('pre code.mermaid svg').forEach((svg) => {
+      var bbox = svg.getBBox()
+      if (bbox.height > 0) {
+        var pad = 16
+        svg.setAttribute('viewBox',
+          (bbox.x - pad) + ' ' + (bbox.y - pad) + ' ' +
+          (bbox.width + pad * 2) + ' ' + (bbox.height + pad * 2))
+      }
+    })
+  }
+
   return {
     render: () => {
       if (loaded) {
@@ -19,7 +31,7 @@ var mmd = (() => {
         state._themes[state.theme] === 'dark' ||
         (state._themes[state.theme] === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches)
         ? 'dark' : 'default'
-      mermaid.initialize({theme})
+      mermaid.initialize({theme, securityLevel: 'loose'})
       mermaid.init({theme}, 'code.mermaid')
       loaded = true
 
@@ -28,6 +40,7 @@ var mmd = (() => {
         var svg = Array.from(document.querySelectorAll('pre code.mermaid svg'))
         if (diagrams.length === svg.length) {
           clearInterval(timeout)
+          setTimeout(fixMermaidViewBox, 100)
           svg.forEach((diagram) => {
             var panzoom = Panzoom(diagram, {canvas: true})
             diagram.parentElement.parentElement.addEventListener('wheel', (e) => {


### PR DESCRIPTION
## Problem

When using `<br>` for line breaks inside Mermaid flowchart node labels (e.g. `A["Line 1<br>Line 2"]`), the text renders on a single line instead of wrapping.

### Root Cause

The GitHub theme CSS contains the rule:
```css
.markdown-body code br { display: none }
```
Since Mermaid diagrams are rendered inside `<code class="mermaid">` elements, `<br>` tags in node labels are hidden by this CSS rule.

Additionally, even after making `<br>` visible, the SVG `viewBox` is pre-calculated for single-line node heights, causing the top of the diagram to be clipped.

## Fix

1. **CSS**: Add `.markdown-body code.mermaid br { display: inline !important }` to override the theme rule specifically for Mermaid elements
2. **JS**: Recalculate SVG `viewBox` using `getBBox()` after Mermaid finishes rendering
3. **JS**: Set `securityLevel: 'loose'` in `mermaid.initialize()` so Mermaid preserves `<br>` HTML tags during rendering

## Demo

Before (single line):
```
A["Line 1<br>Line 2<br>Line 3"]
→ renders as: Line 1Line 2Line 3
```

After (proper line breaks):
```
A["Line 1<br>Line 2<br>Line 3"]
→ renders as:
  Line 1
  Line 2
  Line 3
```

## Workaround

Users can work around this by adding `%%{init: {"flowchart": {"htmlLabels": false}} }%%` at the top of their Mermaid block, which uses SVG text rendering instead of HTML foreignObject. However, this requires modifying every diagram and loses some formatting features.

Fixes #263