### PR TITLE
Guard background messaging and detect startup paths

### DIFF
--- a/background/detect.js
+++ b/background/detect.js
@@ -79,6 +79,10 @@ md.detect = ({storage: {state}, inject}) => {
   }
 
   var detect = (content, url) => {
+    if (!url || !state.origins) {
+      return
+    }
+
     var location = new URL(url)
 
     var origin =

--- a/background/messages.js
+++ b/background/messages.js
@@ -165,7 +165,19 @@ md.messages = ({storage: {defaults, state, set}, compilers, mathjax, xhr, webreq
 
   function notifyContent (req, res) {
     chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-      chrome.tabs.sendMessage(tabs[0].id, req, res)
+      if (!tabs.length) {
+        res && res()
+        return
+      }
+
+      chrome.tabs.sendMessage(tabs[0].id, req, (response) => {
+        if (chrome.runtime.lastError) {
+          res && res()
+          return
+        }
+
+        res && res(response)
+      })
     })
   }
 }


### PR DESCRIPTION
## Summary

This PR adds two defensive guards in the background scripts:

- avoid messaging errors when there is no active content-script receiver
- avoid startup-time detect errors before origin state is initialized

## Changes

- in `background/messages.js`, `notifyContent()` now:
  - returns early when there is no active tab
  - ignores `chrome.runtime.lastError` when a tab has no receiving content script
- in `background/detect.js`, `detect()` now returns early when the URL or `state.origins` is not yet available

## Why

While testing locally, the extension could emit background errors in normal browsing cases:
- "Could not establish connection. Receiving end does not exist."
- errors caused by reading `state.origins` before initialization completed

These guards make those paths no-op safely instead of surfacing runtime noise.

## Scope

This PR intentionally does not include the copy-button feature work.