### PR TITLE
Roundup PR: optional code features, custom-theme improvements + curated community PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - custom themes can extend a base theme
 - custom themes can be stored locally per device (no 8KB limit)
 - custom theme editor gains a css text field next to the file upload
+- toggle to display yaml/toml frontmatter (PR #281)
+- markdown-it grid table plugin (PR #233)
+- allow <br> line breaks in mermaid node labels (PR #289)
+- guard background messaging and detect startup paths (PR #290)
 - fix mdc build on newer node (dart-sass instead of node-sass)
 
 ## v5.3 - 2024-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## Unreleased
 - optional copy buttons for fenced code blocks
 - optional wrapping of long lines in code blocks
+- custom themes can extend a base theme
+- custom themes can be stored locally per device (no 8KB limit)
+- custom theme editor gains a css text field next to the file upload
 - fix mdc build on newer node (dart-sass instead of node-sass)
 
 ## v5.3 - 2024-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change Log
 
+## Unreleased
+- optional copy buttons for fenced code blocks
+- optional wrapping of long lines in code blocks
+- fix mdc build on newer node (dart-sass instead of node-sass)
+
 ## v5.3 - 2024-04-30
 - custom theme support
 - syntax highlighted raw markdown view

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 - Multiple markdown parsers
 - Full control over the compiler options ([markdown-it], [marked], [remark])
 - 30+ Themes ([cleanrmd], [GitHub][github-theme])
-- Custom theme support
+- Custom theme support (extend a base theme; stored synced or locally)
 - GitHub Flavored Markdown (GFM)
 - Auto reload on file change
 - Optional copy buttons for fenced code blocks
+- Optional wrapping of long lines in code blocks
+- Optional display of yaml/toml frontmatter
 - Syntax highlighted code blocks ([prism][prism])
 - Table of Contents (ToC)
 - MathJax formulas ([mathjax])
@@ -76,10 +78,11 @@ The `auto` option on the `github` and `github-dark` themes has a fixed width wit
 
 1. Go to the Advanced Options and click on Settings
 2. Select `CUSTOM` for Content Theme
-3. Upload your Custom Theme below
-4. Specify the Color Scheme of your theme
+3. Optionally pick a Base Theme to extend (leave as `none` for a full custom theme)
+4. Provide your CSS by typing it into the text field or by uploading a `.css` file
+5. Specify the Color Scheme of your theme (full custom themes only; extended themes follow the base theme)
 
-> Your custom theme will be minified automatically on upload and it can be up to 8KB in size.
+> Uploaded `.css` files are minified automatically. Themes are kept in sync storage (shared across devices, up to 8KB per item); themes that exceed that limit are stored locally on the current device instead. You can also select `local` storage explicitly via the Storage option.
 
 > You can add `<link rel="stylesheet" type="text/css" href="file:///home/me/custom-theme.css">` to your markdown document to speed up development while working on your theme. Custom theme [example][custom-theme].
 
@@ -97,6 +100,7 @@ Full **CommonMark** support including **GFM** tables and strikethrough **+**
 | **cjk**        | `false` | Suppress linebreaks between east asian characters
 | **deflist**    | `false` | Definition list `<dl>`
 | **footnote**   | `false` | Footnotes `[^1]` `[^1]: a`
+| **gridtables** | `false` | Support for pandoc grid tables
 | **html**       | **`true`**  | Enable HTML tags in source
 | **ins**        | `false` | Inserted text `++a++` `<ins>`
 | **linkify**    | **`true`**  | Autoconvert URL-like text to links
@@ -114,8 +118,10 @@ Full **CommonMark** support including **GFM** tables and strikethrough **+**
 | Option         | Default | Description
 | :-             | :-:     | :-
 | **autoreload** | `false` | Auto reload on file change
+| **codewrap**   | `false` | Wrap long lines in code blocks instead of scrolling
 | **copy**       | `false` | Show copy buttons on fenced code blocks
 | **emoji**      | `false` | Convert emoji `:shortnames:` into EmojiOne images
+| **frontmatter**| `false` | Display yaml/toml frontmatter
 | **mathjax**    | `false` | Render MathJax formulas
 | **mermaid**    | `false` | Render Mermaid diagrams
 | **syntax**     | **`true`**  | Syntax highlighted fenced code blocks

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Custom theme support
 - GitHub Flavored Markdown (GFM)
 - Auto reload on file change
+- Optional copy buttons for fenced code blocks
 - Syntax highlighted code blocks ([prism][prism])
 - Table of Contents (ToC)
 - MathJax formulas ([mathjax])
@@ -113,6 +114,7 @@ Full **CommonMark** support including **GFM** tables and strikethrough **+**
 | Option         | Default | Description
 | :-             | :-:     | :-
 | **autoreload** | `false` | Auto reload on file change
+| **copy**       | `false` | Show copy buttons on fenced code blocks
 | **emoji**      | `false` | Convert emoji `:shortnames:` into EmojiOne images
 | **mathjax**    | `false` | Render MathJax formulas
 | **mermaid**    | `false` | Render Mermaid diagrams

--- a/background/compilers/markdown-it.js
+++ b/background/compilers/markdown-it.js
@@ -16,6 +16,7 @@ md.compilers['markdown-it'] = (() => {
     cjk: false,
     deflist: false,
     footnote: false,
+    gridTableRulePlugin: false,
     ins: false,
     mark: false,
     sub: false,
@@ -35,6 +36,7 @@ md.compilers['markdown-it'] = (() => {
     cjk: 'Suppress linebreaks between east asian characters',
     deflist: 'Definition list <dl>\ntitle\n: definition',
     footnote: 'Footnotes\nword[^1]\n[^1]: text',
+    gridTableRulePlugin: 'support for pandoc grid_tables',
     ins: 'Inserted text <ins>\n++text++',
     mark: 'Marked text <mark>\n==text==',
     sub: 'Subscript <sub>\n~text~',
@@ -55,6 +57,7 @@ md.compilers['markdown-it'] = (() => {
         .use(state['markdown-it'].cjk ? mdit.cjk : () => {})
         .use(state['markdown-it'].deflist ? mdit.deflist : () => {})
         .use(state['markdown-it'].footnote ? mdit.footnote : () => {})
+        .use(state['markdown-it'].gridTableRulePlugin ? mdit.gridTableRulePlugin : () => {})
         .use(state['markdown-it'].ins ? mdit.ins : () => {})
         .use(state['markdown-it'].mark ? mdit.mark : () => {})
         .use(state['markdown-it'].sub ? mdit.sub : () => {})

--- a/background/detect.js
+++ b/background/detect.js
@@ -79,6 +79,10 @@ md.detect = ({storage: {state}, inject}) => {
   }
 
   var detect = (content, url) => {
+    if (!url || !state.origins) {
+      return
+    }
+
     var location = new URL(url)
 
     var origin =

--- a/background/messages.js
+++ b/background/messages.js
@@ -153,11 +153,42 @@ md.messages = ({storage: {defaults, state, set}, compilers, mathjax, xhr, webreq
       sendResponse(state.custom)
     }
     else if (req.message === 'custom.set') {
-      set({custom: req.custom}).then(sendResponse).catch((err) => {
-        if (/QUOTA_BYTES_PER_ITEM quota exceeded/.test(err.message)) {
-          sendResponse({error: 'Minified theme exceeded 8KB in size!'})
-        }
-      })
+      var custom = {
+        theme: req.custom.theme || '',
+        color: req.custom.color,
+        base: req.custom.base || '',
+      }
+      // local: store on this device only, leave the synced theme untouched
+      if (req.local) {
+        chrome.storage.local.set({custom})
+          .then(() => {
+            state.custom = Object.assign({}, custom, {local: true})
+            sendResponse({local: true})
+          })
+          .catch((err) => sendResponse({error: err.message}))
+      }
+      // sync: store shared; if it is too large for a sync item, keep it local
+      else {
+        set({custom})
+          .then(() => chrome.storage.local.remove('custom'))
+          .then(() => {
+            state.custom = Object.assign({}, custom, {local: false})
+            sendResponse({local: false})
+          })
+          .catch((err) => {
+            if (/quota exceeded/i.test(err.message)) {
+              chrome.storage.local.set({custom})
+                .then(() => {
+                  state.custom = Object.assign({}, custom, {local: true})
+                  sendResponse({local: true, fallback: true})
+                })
+                .catch((err2) => sendResponse({error: err2.message}))
+            }
+            else {
+              sendResponse({error: err.message})
+            }
+          })
+      }
     }
 
     return true

--- a/background/messages.js
+++ b/background/messages.js
@@ -196,7 +196,19 @@ md.messages = ({storage: {defaults, state, set}, compilers, mathjax, xhr, webreq
 
   function notifyContent (req, res) {
     chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-      chrome.tabs.sendMessage(tabs[0].id, req, res)
+      if (!tabs.length) {
+        res && res()
+        return
+      }
+
+      chrome.tabs.sendMessage(tabs[0].id, req, (response) => {
+        if (chrome.runtime.lastError) {
+          res && res()
+          return
+        }
+
+        res && res(response)
+      })
     })
   }
 }

--- a/background/storage.js
+++ b/background/storage.js
@@ -48,6 +48,7 @@ md.storage.defaults = (compilers) => {
     },
     content: {
       autoreload: false,
+      codewrap: false,
       copy: false,
       emoji: false,
       mathjax: false,
@@ -136,6 +137,9 @@ md.storage.migrations = (state) => {
   }
   if (state.content.copy === undefined) {
     state.content.copy = false
+  }
+  if (state.content.codewrap === undefined) {
+    state.content.codewrap = false
   }
   if (state.themes.wide !== undefined) {
     if (state.themes.wide) {

--- a/background/storage.js
+++ b/background/storage.js
@@ -151,6 +151,9 @@ md.storage.migrations = (state) => {
   if (state.content.codewrap === undefined) {
     state.content.codewrap = false
   }
+  if (state.content.frontmatter === undefined) {
+    state.content.frontmatter = false
+  }
   if (state.themes.wide !== undefined) {
     if (state.themes.wide) {
       state.themes.width = 'full'
@@ -190,7 +193,6 @@ md.storage.migrations = (state) => {
       cjk: false,
       deflist: false,
       footnote: false,
-      gridTableRulePlugin: false,
       ins: false,
       mark: false,
       sub: false,
@@ -198,6 +200,9 @@ md.storage.migrations = (state) => {
       tasklists: false,
     })
 
+  }
+  if (state['markdown-it'].gridTableRulePlugin === undefined) {
+    state['markdown-it'].gridTableRulePlugin = false
   }
   if (state.marked.linkify === undefined) {
     Object.assign(state.marked, {

--- a/background/storage.js
+++ b/background/storage.js
@@ -190,6 +190,7 @@ md.storage.migrations = (state) => {
       cjk: false,
       deflist: false,
       footnote: false,
+      gridTableRulePlugin: false,
       ins: false,
       mark: false,
       sub: false,

--- a/background/storage.js
+++ b/background/storage.js
@@ -48,6 +48,7 @@ md.storage.defaults = (compilers) => {
     },
     content: {
       autoreload: false,
+      copy: false,
       emoji: false,
       mathjax: false,
       mermaid: false,
@@ -132,6 +133,9 @@ md.storage.migrations = (state) => {
   }
   if (state.content.syntax === undefined) {
     state.content.syntax = true
+  }
+  if (state.content.copy === undefined) {
+    state.content.copy = false
   }
   if (state.themes.wide !== undefined) {
     if (state.themes.wide) {

--- a/background/storage.js
+++ b/background/storage.js
@@ -30,6 +30,14 @@ md.storage = ({compilers}) => {
     md.storage.migrations(state)
 
     set(state)
+
+    // a locally stored custom theme (this device only) overrides the
+    // synced one; the 'local' flag is derived per device, never synced
+    chrome.storage.local.get('custom').then((res) => {
+      state.custom = res.custom
+        ? Object.assign({}, res.custom, {local: true})
+        : Object.assign({}, state.custom, {local: false})
+    })
   })
 
   return {defaults, state, set}
@@ -70,6 +78,7 @@ md.storage.defaults = (compilers) => {
     custom: {
       theme: '',
       color: 'auto',
+      base: '',
     }
   }
 
@@ -200,5 +209,9 @@ md.storage.migrations = (state) => {
       theme: '',
       color: 'auto'
     }
+  }
+  // custom theme can now extend a base theme
+  if (state.custom.base === undefined) {
+    state.custom.base = ''
   }
 }

--- a/background/storage.js
+++ b/background/storage.js
@@ -59,6 +59,7 @@ md.storage.defaults = (compilers) => {
       codewrap: false,
       copy: false,
       emoji: false,
+      frontmatter: false,
       mathjax: false,
       mermaid: false,
       syntax: true,

--- a/build/README.md
+++ b/build/README.md
@@ -39,6 +39,7 @@ sh build/package.sh
 | markdown-it-cjk-breaks | 1.1.3
 | markdown-it-deflist    | 2.1.0
 | markdown-it-footnote   | 3.0.3
+| markdown-it-gridtables | 0.4.0
 | markdown-it-ins        | 3.0.1
 | markdown-it-mark       | 3.0.1
 | markdown-it-sub        | 1.0.0

--- a/build/markdown-it/markdown-it.mjs
+++ b/build/markdown-it/markdown-it.mjs
@@ -6,6 +6,7 @@ import attrs from 'markdown-it-attrs'
 import cjk from 'markdown-it-cjk-breaks'
 import deflist from 'markdown-it-deflist'
 import footnote from 'markdown-it-footnote'
+import gridTableRulePlugin from 'markdown-it-gridtables'
 import ins from 'markdown-it-ins'
 import mark from 'markdown-it-mark'
 import sub from 'markdown-it-sub'
@@ -21,6 +22,7 @@ export {
   cjk,
   deflist,
   footnote,
+  gridTableRulePlugin,
   ins,
   mark,
   sub,

--- a/build/markdown-it/package.json
+++ b/build/markdown-it/package.json
@@ -12,6 +12,7 @@
     "markdown-it-cjk-breaks": "1.1.3",
     "markdown-it-deflist": "2.1.0",
     "markdown-it-footnote": "3.0.3",
+    "markdown-it-gridtables": "0.4.0",
     "markdown-it-ins": "3.0.1",
     "markdown-it-mark": "3.0.1",
     "markdown-it-sub": "1.0.0",

--- a/build/mdc/build.sh
+++ b/build/mdc/build.sh
@@ -12,7 +12,7 @@ npx rollup --config rollup.mjs --input mdc.mjs --file tmp/mdc.js
 npx terser --compress --mangle -- tmp/mdc.js > tmp/mdc.min.js
 
 # mdc.min.css
-npx node-sass --include-path node_modules/ mdc.scss tmp/mdc.css
+npx sass --load-path=node_modules --no-source-map --quiet mdc.scss tmp/mdc.css
 npx csso --input tmp/mdc.css --output tmp/mdc.min.css
 
 # copy

--- a/build/mdc/package.json
+++ b/build/mdc/package.json
@@ -14,8 +14,8 @@
     "@rollup/plugin-commonjs": "23.0.2",
     "@rollup/plugin-node-resolve": "15.0.1",
     "csso-cli": "4.0.2",
-    "node-sass": "9.0.0",
     "rollup": "3.29.4",
+    "sass": "1.77.8",
     "terser": "5.30.3"
   },
   "engines": {

--- a/content/index.css
+++ b/content/index.css
@@ -359,3 +359,89 @@ img.emojione {
   /* prevent img stretch */
   width: auto;
 }
+
+/*---------------------------------------------------------------------------*/
+/*copy button*/
+
+.markdown-theme pre._copy-enabled,
+.markdown-body pre._copy-enabled,
+pre[class*=language-]._copy-enabled {
+  position: relative;
+  padding-top: 44px !important;
+}
+
+.markdown-theme ._copy-button,
+.markdown-body ._copy-button,
+pre[class*=language-] ._copy-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 2;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  padding: 6px 10px;
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    --copy-button-bg: rgba(255, 255, 255, 0.92);
+    --copy-button-fg: #24292f;
+    --copy-button-border: rgba(31, 35, 40, 0.15);
+    --copy-button-hover: #f6f8fa;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    --copy-button-bg: rgba(22, 27, 34, 0.92);
+    --copy-button-fg: #e6edf3;
+    --copy-button-border: rgba(240, 246, 252, 0.12);
+    --copy-button-hover: #30363d;
+  }
+}
+
+._color-light {
+  --copy-button-bg: rgba(255, 255, 255, 0.92);
+  --copy-button-fg: #24292f;
+  --copy-button-border: rgba(31, 35, 40, 0.15);
+  --copy-button-hover: #f6f8fa;
+  --copy-button-marked-bg: #1f883d;
+  --copy-button-marked-fg: #ffffff;
+  --copy-button-marked-border: #1a7f37;
+}
+
+._color-dark {
+  --copy-button-bg: rgba(22, 27, 34, 0.92);
+  --copy-button-fg: #e6edf3;
+  --copy-button-border: rgba(240, 246, 252, 0.12);
+  --copy-button-hover: #30363d;
+  --copy-button-marked-bg: #238636;
+  --copy-button-marked-fg: #ffffff;
+  --copy-button-marked-border: #2ea043;
+}
+
+.markdown-theme ._copy-button,
+.markdown-body ._copy-button,
+pre[class*=language-] ._copy-button {
+  background: var(--copy-button-bg);
+  color: var(--copy-button-fg);
+  border-color: var(--copy-button-border);
+}
+
+.markdown-theme ._copy-button:hover,
+.markdown-body ._copy-button:hover,
+pre[class*=language-] ._copy-button:hover {
+  background: var(--copy-button-hover);
+}
+
+.markdown-theme ._copy-button._copy-button-marked,
+.markdown-body ._copy-button._copy-button-marked,
+pre[class*=language-] ._copy-button._copy-button-marked {
+  background: var(--copy-button-marked-bg);
+  color: var(--copy-button-marked-fg);
+  border-color: var(--copy-button-marked-border);
+}

--- a/content/index.css
+++ b/content/index.css
@@ -342,6 +342,13 @@ pre:has(> code.mermaid) {
   height: 100%;
 }
 
+/*allow <br> line breaks inside mermaid node labels; the github theme
+  hides them via `code br { display: none }`*/
+.markdown-body code.mermaid br,
+.markdown-theme code.mermaid br {
+  display: inline !important;
+}
+
 /*mermaid text bold effect*/
 svg[id^=mermaid] text {
   stroke: none !important;

--- a/content/index.css
+++ b/content/index.css
@@ -68,6 +68,13 @@ pre#_markdown,
   overflow-y: auto;
 }
 
+.frontmatter pre,
+.frontmatter pre code {
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  overflow-wrap: break-word !important;
+}
+
 @media (max-width: 576px) { /*Extra small - none*/
   .markdown-theme { width: auto !important; }
 }

--- a/content/index.css
+++ b/content/index.css
@@ -463,11 +463,11 @@ pre[class*=language-] ._copy-button._copy-button-marked {
 /*---------------------------------------------------------------------------*/
 /*code wrap*/
 
-body._code-wrap .markdown-body pre,
-body._code-wrap .markdown-body pre > code,
-body._code-wrap .markdown-body pre code,
-body._code-wrap .markdown-theme pre,
-body._code-wrap .markdown-theme pre code,
+body._code-wrap .markdown-body pre:not(:has(> code.mermaid)),
+body._code-wrap .markdown-body pre > code:not(.mermaid),
+body._code-wrap .markdown-body pre code:not(.mermaid),
+body._code-wrap .markdown-theme pre:not(:has(> code.mermaid)),
+body._code-wrap .markdown-theme pre code:not(.mermaid),
 body._code-wrap pre[class*=language-],
 body._code-wrap pre[class*=language-] code,
 body._code-wrap code[class*=language-],
@@ -478,9 +478,10 @@ body._code-wrap #_markdown > pre > code {
   word-break: break-word !important;
 }
 
-/*hanging indent so wrapped lines are distinguishable from real ones*/
-body._code-wrap .markdown-body pre,
-body._code-wrap .markdown-theme pre,
+/*hanging indent so wrapped lines are distinguishable from real ones;
+  mermaid diagram containers are excluded so their layout is untouched*/
+body._code-wrap .markdown-body pre:not(:has(> code.mermaid)),
+body._code-wrap .markdown-theme pre:not(:has(> code.mermaid)),
 body._code-wrap pre[class*=language-],
 body._code-wrap pre#_markdown {
   text-indent: -2em each-line;

--- a/content/index.css
+++ b/content/index.css
@@ -445,3 +445,30 @@ pre[class*=language-] ._copy-button._copy-button-marked {
   color: var(--copy-button-marked-fg);
   border-color: var(--copy-button-marked-border);
 }
+
+/*---------------------------------------------------------------------------*/
+/*code wrap*/
+
+body._code-wrap .markdown-body pre,
+body._code-wrap .markdown-body pre > code,
+body._code-wrap .markdown-body pre code,
+body._code-wrap .markdown-theme pre,
+body._code-wrap .markdown-theme pre code,
+body._code-wrap pre[class*=language-],
+body._code-wrap pre[class*=language-] code,
+body._code-wrap code[class*=language-],
+body._code-wrap pre#_markdown,
+body._code-wrap #_markdown > pre > code {
+  white-space: pre-wrap !important;
+  overflow-wrap: break-word !important;
+  word-break: break-word !important;
+}
+
+/*hanging indent so wrapped lines are distinguishable from real ones*/
+body._code-wrap .markdown-body pre,
+body._code-wrap .markdown-theme pre,
+body._code-wrap pre[class*=language-],
+body._code-wrap pre#_markdown {
+  text-indent: -2em each-line;
+  padding-left: calc(2em + 16px) !important;
+}

--- a/content/index.js
+++ b/content/index.js
@@ -316,7 +316,7 @@ var copybuttons = (() => {
         return
       }
 
-      root.querySelectorAll('pre > code[class*="language-"]').forEach((code) => {
+      root.querySelectorAll('pre > code:not(.mermaid)').forEach((code) => {
         var pre = code.parentElement
         if (!pre || pre.querySelector('._copy-button')) {
           return

--- a/content/index.js
+++ b/content/index.js
@@ -119,7 +119,7 @@ var render = (md) => {
   chrome.runtime.sendMessage({
     message: 'markdown',
     compiler: state.compiler,
-    markdown: frontmatter(state.markdown)
+    markdown: frontmatter(state.markdown, state.content.frontmatter)
   }, (res) => {
     state.html = res.html
     if (state.content.emoji) {
@@ -336,18 +336,29 @@ var copybuttons = (() => {
   }
 })()
 
-var frontmatter = (md) => {
-  if (/^-{3}[\s\S]+?-{3}/.test(md)) {
-    var [, yaml] = /^-{3}([\s\S]+?)-{3}/.exec(md)
-    var title = /title: (?:'|")*(.*)(?:'|")*/.exec(yaml)
+var frontmatter = (md, show) => {
+  var yamlMatch = /^(-{3})([\s\S]+?)(-{3})/.exec(md)
+  var tomlMatch = /^(\+{3})([\s\S]+?)(\+{3})/.exec(md)
+
+  if (yamlMatch) {
+    var [full, , content] = yamlMatch
+    var title = /title: (?:'|")*(.*)(?:'|")*/.exec(content)
     title && (document.title = title[1])
+    if (show) {
+      return md.replace(full, '<div class="frontmatter">\n\n```yaml\n' + content.trim() + '\n```\n\n</div>\n\n')
+    }
+    return md.replace(full, '')
   }
-  else if (/^\+{3}[\s\S]+?\+{3}/.test(md)) {
-    var [, toml] = /^\+{3}([\s\S]+?)\+{3}/.exec(md)
-    var title = /title = (?:'|"|`)*(.*)(?:'|"|`)*/.exec(toml)
+  else if (tomlMatch) {
+    var [full, , content] = tomlMatch
+    var title = /title = (?:'|"|`)*(.*)(?:'|"|`)*/.exec(content)
     title && (document.title = title[1])
+    if (show) {
+      return md.replace(full, '<div class="frontmatter">\n\n```toml\n' + content.trim() + '\n```\n\n</div>\n\n')
+    }
+    return md.replace(full, '')
   }
-  return md.replace(/^(?:-|\+){3}[\s\S]+?(?:-|\+){3}/, '')
+  return md
 }
 
 var favicon = () => {

--- a/content/index.js
+++ b/content/index.js
@@ -154,18 +154,24 @@ function mount () {
       if (state.html) {
         state._themes.custom = state.custom.color
 
+        // a custom theme may extend a base theme; resolve the theme whose
+        // stylesheet, color scheme and wrapper class should actually apply
+        var effective = state.theme === 'custom' && state.custom.base
+          ? state.custom.base
+          : state.theme
+
         var color =
-          state._themes[state.theme] === 'dark' ||
-          (state._themes[state.theme] === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+          state._themes[effective] === 'dark' ||
+          (state._themes[effective] === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches)
           ? 'dark' : 'light'
 
         $('body').classList.remove(...Array.from($('body').classList).filter((name) => /^_theme|_color/.test(name)))
         dom.push(m('link#_theme', {
           onupdate: onupdate.theme,
           rel: 'stylesheet', type: 'text/css',
-          href: state.theme !== 'custom' ? chrome.runtime.getURL(`/themes/${state.theme}.css`) : '',
+          href: effective !== 'custom' ? chrome.runtime.getURL(`/themes/${effective}.css`) : '',
         }))
-        $('body').classList.add(`_theme-${state.theme}`, `_color-${color}`)
+        $('body').classList.add(`_theme-${effective}`, `_color-${color}`)
 
         state.content.codewrap
           ? $('body').classList.add('_code-wrap')
@@ -179,7 +185,7 @@ function mount () {
         }
 
         var theme =
-          (/github(-dark)?/.test(state.theme) ? 'markdown-body' : 'markdown-theme') +
+          (/github(-dark)?/.test(effective) ? 'markdown-body' : 'markdown-theme') +
           (state.themes.width !== 'auto' ? ` _width-${state.themes.width}` : '')
 
         if (state.raw) {

--- a/content/index.js
+++ b/content/index.js
@@ -103,6 +103,8 @@ var update = (update) => {
     setTimeout(() => Prism.highlightAll(), 20)
   }
 
+  setTimeout(() => copybuttons.render(), 30)
+
   if (state.content.mermaid) {
     setTimeout(() => mmd.render(), 40)
   }
@@ -230,6 +232,97 @@ var toc = (() => {
         '<a href="#' + id + '">' + title.replace(/<a[^>]+>/g, '').replace(/<\/a>/g, '') + '</a>' +
         '</div>'.repeat(level)
       , '')
+  }
+})()
+
+var copybuttons = (() => {
+  var copied = (value) =>
+    value.replace(/[\r\n]+$/, '')
+
+  var text = (button, next) => {
+    button.textContent = next
+    clearTimeout(button._timeout)
+    if (next !== 'Copy') {
+      button._timeout = setTimeout(() => {
+        button.textContent = 'Copy'
+      }, 1500)
+    }
+  }
+
+  var fallback = (value) => {
+    var textarea = document.createElement('textarea')
+    textarea.value = value
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'fixed'
+    textarea.style.top = '-9999px'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.select()
+    var ok = false
+    try {
+      ok = document.execCommand('copy')
+    }
+    catch (_) {}
+    document.body.removeChild(textarea)
+    return ok
+  }
+
+  var write = async (value) => {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(value)
+        return true
+      }
+      catch (_) {}
+    }
+    return fallback(value)
+  }
+
+  var click = async (event) => {
+    var button = event.currentTarget
+    var value = button._code ? copied(button._code.textContent || '') : ''
+    var ok = value && await write(value)
+    if (ok) {
+      button.classList.toggle('_copy-button-marked')
+    }
+    text(button, ok ? 'Copied' : 'Error')
+  }
+
+  var clear = (root) => {
+    root.querySelectorAll('._copy-button').forEach((button) => button.remove())
+    root.querySelectorAll('pre._copy-enabled').forEach((block) => block.classList.remove('_copy-enabled'))
+  }
+
+  return {
+    render: () => {
+      var root = document.querySelector('#_html')
+      if (!root) {
+        return
+      }
+
+      clear(root)
+
+      if (state.raw || !state.content.copy) {
+        return
+      }
+
+      root.querySelectorAll('pre > code[class*="language-"]').forEach((code) => {
+        var pre = code.parentElement
+        if (!pre || pre.querySelector('._copy-button')) {
+          return
+        }
+
+        pre.classList.add('_copy-enabled')
+
+        var button = document.createElement('button')
+        button.type = 'button'
+        button.className = '_copy-button'
+        button.textContent = 'Copy'
+        button._code = code
+        button.addEventListener('click', click)
+        pre.insertBefore(button, pre.firstChild)
+      })
+    }
   }
 })()
 

--- a/content/index.js
+++ b/content/index.js
@@ -167,6 +167,10 @@ function mount () {
         }))
         $('body').classList.add(`_theme-${state.theme}`, `_color-${color}`)
 
+        state.content.codewrap
+          ? $('body').classList.add('_code-wrap')
+          : $('body').classList.remove('_code-wrap')
+
         if (state.content.syntax) {
           dom.push(m('link#_prism', {
             rel: 'stylesheet', type: 'text/css',

--- a/options/custom.js
+++ b/options/custom.js
@@ -3,70 +3,90 @@ var Custom = () => {
   var defaults = {
     theme: '',
     color: 'auto',
-    _colors: ['auto', 'light', 'dark'],
+    base: '',
+    local: false,
+    fallback: false,
+    draft: '',
     error: '',
+    _colors: ['auto', 'light', 'dark'],
+    _storages: ['sync', 'local'],
+    _bases: [
+      '',
+      'github', 'github-dark', 'almond', 'awsm', 'axist', 'bamboo',
+      'bullframe', 'holiday', 'kacit', 'latex', 'marx', 'mini', 'modest',
+      'new', 'no-class', 'pico', 'retro', 'sakura', 'sakura-vader',
+      'semantic', 'simple', 'style-sans', 'style-serif', 'stylize',
+      'superstylin', 'tacit', 'vanilla', 'water', 'water-dark', 'writ',
+    ],
   }
 
   var state = Object.assign({}, defaults)
 
   chrome.runtime.sendMessage({message: 'custom.get'}, (res) => {
     Object.assign(state, res)
+    state.draft = state.theme
     m.redraw()
   })
+
+  // sends theme + color + base; the background stores it in sync, or
+  // falls back to local storage when it is too large for a sync item
+  var save = (theme) => {
+    chrome.runtime.sendMessage({
+      message: 'custom.set',
+      local: state.local,
+      custom: {theme: theme, color: state.color, base: state.base},
+    }, (res) => {
+      if (res?.error) {
+        state.error = res.error
+      }
+      else {
+        state.theme = theme
+        state.draft = theme
+        state.local = !!(res && res.local)
+        state.fallback = !!(res && res.fallback)
+        state.error = ''
+      }
+      m.redraw()
+    })
+  }
 
   var events = {
     file: (e) => {
       document.querySelector('input[type=file]').click()
     },
-    theme: (e) => {
+    // uploaded files get minified before storing
+    upload: (e) => {
       var file = e.target.files[0]
       if (file) {
-        var minified
         var reader = new FileReader()
         reader.readAsText(file, 'UTF-8')
         reader.onload = (e) => {
-          minified = csso.minify(e.target.result).css
-          chrome.runtime.sendMessage({
-            message: 'custom.set',
-            custom: {
-              theme: minified,
-              color: state.color,
-            },
-          }, (res) => {
-            if (res?.error) {
-              state.error = res.error
-            }
-            else {
-              state.theme = minified
-              state.error = ''
-            }
-            m.redraw()
-          })
+          save(csso.minify(e.target.result).css)
         }
       }
     },
+    // typed css is stored as-is so it stays editable
+    input: (e) => {
+      state.draft = e.target.value
+    },
+    apply: (e) => {
+      save(state.draft)
+    },
     remove: (e) => {
-      state.theme = ''
-      state.error = ''
-      chrome.runtime.sendMessage({
-        message: 'custom.set',
-        custom: {
-          theme: state.theme,
-          color: state.color,
-        },
-      })
-      m.redraw()
+      save('')
+    },
+    base: (e) => {
+      state.base = state._bases[e.target.selectedIndex]
+      save(state.theme)
+    },
+    storage: (e) => {
+      state.local = state._storages[e.target.selectedIndex] === 'local'
+      save(state.theme)
     },
     color: (e) => {
       state.color = state._colors[e.target.selectedIndex]
-      chrome.runtime.sendMessage({
-        message: 'custom.set',
-        custom: {
-          theme: state.theme,
-          color: state.color,
-        },
-      })
-    }
+      save(state.theme)
+    },
   }
 
   var oncreate = {
@@ -85,18 +105,63 @@ var Custom = () => {
           m('span.m-label.m-error', state.error)
         )
       ),
+
+      // base theme to extend (none = full custom theme)
       m('.row',
         m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
-          m('span.m-label',
-            'Custom Theme'
+          m('span.m-label', 'Base Theme')
+        ),
+        m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
+          m('select.mdc-elevation--z2 m-select', {onchange: events.base},
+            state._bases.map((base) =>
+              m('option', {selected: state.base === base}, base || 'none (full custom)')
+            )
           )
+        ),
+      ),
+
+      // css editor (typed css is stored unminified and stays editable)
+      m('.row',
+        m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
+          m('span.m-label', 'Custom CSS')
+        ),
+        m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
+          m('textarea.mdc-elevation--z2 m-textarea', {
+            rows: 8,
+            spellcheck: false,
+            value: state.draft,
+            oninput: events.input,
+            style: {
+              width: '100%',
+              minHeight: '160px',
+              fontFamily: 'monospace',
+              fontSize: '12px',
+              boxSizing: 'border-box',
+            },
+            placeholder: state.base
+              ? '/* overrides for the base theme */'
+              : '/* full custom theme css */',
+          }),
+          m('button.mdc-button mdc-button--raised m-button', {
+            oncreate: oncreate.ripple,
+            onclick: events.apply,
+            },
+            'Save'
+          ),
+        ),
+      ),
+
+      // .css file upload (minified on upload)
+      m('.row',
+        m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
+          m('span.m-label', 'Upload .css')
         ),
         m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
           m('input', {
             type: 'file',
             accept: '.css',
-            onchange: events.theme,
-            oncancel: events.theme,
+            onchange: events.upload,
+            oncancel: events.upload,
           }),
           m('button.mdc-button mdc-button--raised m-button', {
             oncreate: oncreate.ripple,
@@ -113,7 +178,31 @@ var Custom = () => {
           ),
         ),
       ),
-      state.theme &&
+
+      // storage location: sync (shared) or local (this device only)
+      m('.row',
+        m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
+          m('span.m-label', 'Storage')
+        ),
+        m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
+          m('select.mdc-elevation--z2 m-select', {
+            onchange: events.storage
+            },
+            state._storages.map((s) =>
+              m('option', {
+                selected: (s === 'local') === state.local,
+              }, s === 'local' ? 'local (this device)' : 'sync (shared)')
+            )
+          ),
+          state.fallback &&
+          m('span.m-label', {style: {display: 'block', marginTop: '6px'}},
+            'too large for sync — kept locally on this device'
+          )
+        ),
+      ),
+
+      // color scheme (only for full custom; extend inherits the base color)
+      state.theme && !state.base &&
       m('.row',
         m('.col-xxl-6.col-xl-6.col-lg-6.col-md-6.col-sm-12',
           m('span.m-label',

--- a/popup/index.js
+++ b/popup/index.js
@@ -60,6 +60,7 @@ var Popup = () => {
       compiler: {},
       content: {
         autoreload: 'Auto reload on file change',
+        codewrap: 'Wrap long lines in code blocks',
         copy: 'Show copy buttons on fenced code blocks',
         emoji: 'Convert emoji :shortnames: into EmojiOne images',
         toc: 'Generate Table of Contents',

--- a/popup/index.js
+++ b/popup/index.js
@@ -63,6 +63,7 @@ var Popup = () => {
         codewrap: 'Wrap long lines in code blocks',
         copy: 'Show copy buttons on fenced code blocks',
         emoji: 'Convert emoji :shortnames: into EmojiOne images',
+        frontmatter: 'Display yaml/toml frontmatter',
         toc: 'Generate Table of Contents',
         mathjax: 'Render MathJax formulas',
         mermaid: 'Mermaid diagrams',

--- a/popup/index.js
+++ b/popup/index.js
@@ -60,6 +60,7 @@ var Popup = () => {
       compiler: {},
       content: {
         autoreload: 'Auto reload on file change',
+        copy: 'Show copy buttons on fenced code blocks',
         emoji: 'Convert emoji :shortnames: into EmojiOne images',
         toc: 'Generate Table of Contents',
         mathjax: 'Render MathJax formulas',


### PR DESCRIPTION
## Summary

> **This is a roundup PR bundling several independent changes; each can be split out into its own PR on request.**

This branch collects several **optional, off-by-default** enhancements plus a
build fix, and consolidates a few sound but currently unmerged community PRs
into one place. Nothing changes the default behavior — every new option starts
disabled and existing installs keep working as before.

Compare: `DrPepperBianco:feature/enhancements` → `simov:main`

Happy to split this into separate PRs if that is easier to review.

## New options / features (original work in this branch)

- **Wrap long lines in code blocks** — new `content.codewrap` option (default
  off). When enabled, fenced code blocks wrap (`white-space: pre-wrap`) instead
  of scrolling horizontally, with a hanging indent so wrapped lines stay
  distinguishable. Mermaid diagram containers are excluded.
- **Extend a base theme in custom themes** — a custom theme can now pick a base
  theme (e.g. `github-dark`) and only override parts of it, instead of shipping
  a full stylesheet. Uses less storage.
- **Per-device local storage for custom themes** — custom themes can be stored
  in `chrome.storage.local` (no 8KB item limit) as a per-device override; when
  a synced theme exceeds the sync item quota it falls back to local storage
  automatically. The options editor also gains a CSS text field next to the
  file upload.
- **Fix mdc build on newer Node** — `node-sass` no longer builds on current
  Node/Windows (deprecated, no working prebuilt binary); switched the mdc
  stylesheet step to `dart-sass`.

## Consolidated community PRs (with attribution)

These were rebased/cherry-picked; original commit authorship is preserved.

- **#291 — copy buttons for fenced code blocks** (by @geauxtigers). Taken, but
  trimmed: the original also re-ran `content/index.css` through a formatter
  (reindent + stripped comments); that unrelated churn was dropped, keeping only
  the copy-button rules.
- **#290 — guard background messaging and detect startup paths** (by
  @geauxtigers). Taken as-is; avoids errors when `detect` runs before state is
  loaded and when `notifyContent` has no active tab / content script.
- **#281 — toggle to display yaml/toml frontmatter** (by @Tristan-Wilson).
  Taken; additionally added the missing storage migration so the toggle also
  appears for existing installs.
- **#233 — markdown-it grid table plugin** (by @ai-da-kn). Taken; moved the
  migration out of the pre-v5.2 block so it also runs for existing installs.
- **#289 — allow `<br>` line breaks in mermaid node labels** (by @koyo922).
  Partially taken: only the CSS fix (the github theme hides `<br>` inside
  `code`). The PR's `securityLevel: 'loose'` change was intentionally omitted,
  as it widens the HTML/JS injection surface for untrusted markdown files.

## Intentionally NOT included (and why)

- **#246 — copy button via the Prism plugin.** Superseded by the self-contained
  implementation from #291 (no dependency on the Prism toolbar, works without a
  vendor rebuild).
- **#298 — copy button + popup markdown previewer with history.** The copy
  button overlaps #291; the popup previewer is a large, separate feature that
  also bundles unrelated prism/mathjax changes.
- **#169 — GitLab-style math expressions.** Based on an obsolete architecture
  (injects MathJax from a CDN in the content script); incompatible with the
  current vendor-based MathJax and the extension's offline/CSP design.
- **#190 — collapsible ToC.** Patches an older ToC implementation that has since
  been rewritten; would not integrate cleanly, and the code quality is low.
- **#261 — MultiMarkdown tables + ruby.** Too invasive/risky as-is: bumps
  markdown-it 13 → 14, relies on a manual "patch the vendor bundle" TODO,
  disables the themes build, and adds a stray root `package.json`.
- **#264 — Plotly diagrams.** Heavy: pulls in a large Plotly vendor library
  (significant bundle size increase) for a niche use case.

## Notes

- Every feature is opt-in and defaults to the current behavior.
- The `themes/` and `vendor/` build artifacts are not included (they are
  git-ignored); `#233` needs a `markdown-it` vendor rebuild, which
  `build/package.sh` handles.
- README and CHANGELOG are updated accordingly.
