### PR TITLE
fix: skip cache-busting and wake-up reload for file:// URLs

### DIFF
--- a/background/detect.js
+++ b/background/detect.js
@@ -65,7 +65,7 @@ md.detect = ({storage: {state}, inject}) => {
           }
 
           if (detect(win.header, win.url)) {
-            if (onwakeup && chrome.webRequest) {
+            if (onwakeup && chrome.webRequest && !win.url.startsWith('file:')) {
               onwakeup = false
               chrome.tabs.reload(id)
             }

--- a/background/xhr.js
+++ b/background/xhr.js
@@ -5,7 +5,8 @@ md.xhr = () => {
     ;(async () => {
       await new Promise(async (resolve, reject) => {
         try {
-          var res = await fetch(url + '?preventCache=' + Date.now())
+          var bust = url.startsWith('file:') ? '' : '?preventCache=' + Date.now()
+          var res = await fetch(url + bust)
           done(null, await res.text())
         }
         catch (err) {


### PR DESCRIPTION
## Problem

When the service worker wakes up on a `file://` tab, the console fills with:

```
Unsafe attempt to load URL file:///.../file.md from frame with URL file:///.../file.md.
'file:' URLs are treated as unique security origins.
```

and the autoreload poll fails for local files.

## Root cause

Two spots assume `file://` behaves like `http(s)://`:

1. **`background/detect.js` — wake-up reload.** The `onwakeup` branch calls `chrome.tabs.reload(id)` whenever `chrome.webRequest` is present. But `webRequest` only fires for `http`/`https` navigations — it cannot observe `file://` loads (see README, issue #41). So on wake-up, a `file://` tab gets a pointless full reload that re-triggers the raw-text load and races the content-script re-inject, surfacing the `file:` unique-security-origin error.

2. **`background/xhr.js` — autoreload fetch.** Every URL — including `file://` paths — got `?preventCache=` + `Date.now()` appended. `file:` URLs aren't cached, and some Chrome versions reject the query string on `file:` fetches, so the autoreload poll throws and the extension logs `res.err`.

## Fix

- `detect.js`: guard the `onwakeup` reload with `!win.url.startsWith('file:')` so `file://` tabs fall through to `inject()` instead of reloading.
- `xhr.js`: only append the cache-busting query string for non-`file:` URLs.

## Repro

1. Open a local `.md` file (`file:///...`) in Chrome with the extension and **Allow access to file URLs** enabled.
2. Leave the tab open long enough for the MV3 service worker to suspend (or click "Service Worker → Stop" in `chrome://extensions`).
3. Reload the tab / trigger the wake-up.
4. Observe the `Unsafe attempt to load URL ... 'file:' URLs are treated as unique security origins` error in the service-worker console, and (with autoreload on) the `xhr` fetch error.

After this patch, the wake-up path injects without reloading and the autoreload poll no longer appends a query string to `file:` URLs.

```diff
// background/detect.js
-          if (onwakeup && chrome.webRequest) {
+          if (onwakeup && chrome.webRequest && !win.url.startsWith('file:')) {

// background/xhr.js
-        var res = await fetch(url + '?preventCache=' + Date.now())
+        var bust = url.startsWith('file:') ? '' : '?preventCache=' + Date.now()
+        var res = await fetch(url + bust)
```

Related: #288, #131.