### PR TITLE
Add file explorer sidebar for local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Auto reload on file change
 - Syntax highlighted code blocks ([prism][prism])
 - Table of Contents (ToC)
+- File explorer for local files
 - MathJax formulas ([mathjax])
 - Mermaid diagrams ([mermaid])
 - Convert emoji shortnames (icons provided free by [EmojiOne][emojione])

--- a/background/files.js
+++ b/background/files.js
@@ -1,0 +1,72 @@
+
+md.files = ({storage: {state}, xhr}) => {
+
+  var unescape = (str) =>
+    str.replace(/&(amp|lt|gt|quot|#39);/g, (_, name) => ({
+      amp: '&', lt: '<', gt: '>', quot: '"', '#39': "'"
+    }[name]))
+
+  // chrome: <script>addRow("name","href",isdir,size,"size",modified,"modified");</script>
+  var chrome = (html) => {
+    var regex = /addRow\("((?:[^"\\]|\\.)*)","((?:[^"\\]|\\.)*)",(\d)/g
+    var entries = []
+    var match
+    while ((match = regex.exec(html))) {
+      entries.push({
+        name: JSON.parse(`"${match[1]}"`),
+        href: match[2],
+        dir: match[3] === '1',
+      })
+    }
+    return entries
+  }
+
+  // firefox: <a class="dir" href="name/">name</a> / <a class="file" href="name">name</a>
+  var firefox = (html) => {
+    var regex = /<a class="(dir|file)" href="([^"]*)">([^<]*)<\/a>/g
+    var entries = []
+    var match
+    while ((match = regex.exec(html))) {
+      entries.push({
+        name: unescape(match[3]),
+        href: match[2],
+        dir: match[1] === 'dir',
+      })
+    }
+    return entries
+  }
+
+  var parse = (base, html) => {
+    var origin = state.origins['file://']
+    var match = new RegExp(origin && origin.match || state.match)
+
+    var entries = (/addRow\(/.test(html) ? chrome(html) : firefox(html))
+      .filter(({name}) => name !== '.' && name !== '..' && name[0] !== '.')
+      .map(({name, href, dir}) => ({
+        name,
+        dir,
+        url: base + href.replace(/\/+$/, '') + (dir ? '/' : ''),
+      }))
+      .filter(({dir, url}) => dir || match.test(url))
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true, sensitivity: 'base'}))
+
+    return {
+      dirs: entries.filter(({dir}) => dir),
+      files: entries.filter(({dir}) => !dir),
+    }
+  }
+
+  var get = (url, done) => {
+    var base = url.replace(/\/*$/, '/')
+    xhr.raw(base, (err, body) => {
+      if (err) {
+        done({err: err.message || String(err)})
+      }
+      else {
+        done(parse(base, body))
+      }
+    })
+  }
+
+  return {get, parse}
+}

--- a/background/index.js
+++ b/background/index.js
@@ -13,6 +13,7 @@ importScripts('/background/inject.js')
 importScripts('/background/messages.js')
 importScripts('/background/mathjax.js')
 importScripts('/background/xhr.js')
+importScripts('/background/files.js')
 importScripts('/background/icon.js')
 
 ;(() => {
@@ -22,6 +23,7 @@ importScripts('/background/icon.js')
   var webrequest = md.webrequest({storage})
   var mathjax = md.mathjax()
   var xhr = md.xhr()
+  var files = md.files({storage, xhr})
   var icon = md.icon({storage})
 
   var compilers = Object.keys(md.compilers)
@@ -30,7 +32,7 @@ importScripts('/background/icon.js')
       all
     ), {})
 
-  var messages = md.messages({storage, compilers, mathjax, xhr, webrequest, icon})
+  var messages = md.messages({storage, compilers, mathjax, xhr, files, webrequest, icon})
 
   chrome.tabs.onUpdated.addListener(detect.tab)
   chrome.runtime.onMessage.addListener(messages)

--- a/background/inject.js
+++ b/background/inject.js
@@ -35,6 +35,7 @@ md.inject = ({storage: {state}}) => (id) => {
       state.content.emoji && '/content/emoji.js',
       state.content.mermaid && ['/vendor/mermaid.min.js', '/vendor/panzoom.min.js', '/content/mermaid.js'],
       state.content.mathjax && ['/content/mathjax.js', '/vendor/mathjax/tex-mml-chtml.js'],
+      state.content.files && '/content/files.js',
       '/content/index.js',
       '/content/scroll.js',
       state.content.autoreload && '/content/autoreload.js',

--- a/background/messages.js
+++ b/background/messages.js
@@ -1,5 +1,5 @@
 
-md.messages = ({storage: {defaults, state, set}, compilers, mathjax, xhr, webrequest, icon}) => {
+md.messages = ({storage: {defaults, state, set}, compilers, mathjax, xhr, files, webrequest, icon}) => {
 
   return (req, sender, sendResponse) => {
 
@@ -24,6 +24,9 @@ md.messages = ({storage: {defaults, state, set}, compilers, mathjax, xhr, webreq
       xhr.get(req.location, (err, body) => {
         sendResponse({err, body})
       })
+    }
+    else if (req.message === 'files') {
+      files.get(req.url, sendResponse)
     }
     else if (req.message === 'prism') {
       chrome.scripting.executeScript({

--- a/background/storage.js
+++ b/background/storage.js
@@ -53,6 +53,7 @@ md.storage.defaults = (compilers) => {
       mermaid: false,
       syntax: true,
       toc: false,
+      files: false,
     },
     origins: {
       'file://': {
@@ -192,5 +193,9 @@ md.storage.migrations = (state) => {
       theme: '',
       color: 'auto'
     }
+  }
+  // v5.3 -> v5.4
+  if (state.content.files === undefined) {
+    state.content.files = false
   }
 }

--- a/background/xhr.js
+++ b/background/xhr.js
@@ -1,11 +1,11 @@
 
 md.xhr = () => {
 
-  var get = (url, done) => {
+  var request = (url, done) => {
     ;(async () => {
       await new Promise(async (resolve, reject) => {
         try {
-          var res = await fetch(url + '?preventCache=' + Date.now())
+          var res = await fetch(url)
           done(null, await res.text())
         }
         catch (err) {
@@ -15,5 +15,9 @@ md.xhr = () => {
     })()
   }
 
-  return {get}
+  var get = (url, done) => request(url + '?preventCache=' + Date.now(), done)
+
+  var raw = (url, done) => request(url, done)
+
+  return {get, raw}
 }

--- a/content/files.js
+++ b/content/files.js
@@ -1,0 +1,146 @@
+
+var files = (() => {
+  var strip = (url) => url.replace(/[#?].*$/, '')
+  var dir = (url) => strip(url).replace(/[^\/]*$/, '')
+  var parent = (url) => url.replace(/[^\/]+\/$/, '')
+  var decode = (url) => {
+    try {
+      return decodeURIComponent(url)
+    }
+    catch (err) {
+      return url
+    }
+  }
+  var same = (a, b) => a === b || decode(a) === decode(b)
+  var basename = (url) => {
+    try {
+      return decodeURIComponent(url.replace(/\/$/, '').split('/').pop())
+    }
+    catch (err) {
+      return url.replace(/\/$/, '').split('/').pop()
+    }
+  }
+
+  var key = 'md-files'
+  var st = {
+    root: '',
+    current: '',
+    open: {},
+    tree: {},
+    loading: {},
+  }
+
+  var save = () => {
+    try {
+      localStorage.setItem(key, JSON.stringify({
+        root: st.root,
+        open: Object.keys(st.open).filter((url) => st.open[url]),
+      }))
+    }
+    catch (err) {}
+  }
+
+  var restore = () => {
+    try {
+      return JSON.parse(localStorage.getItem(key)) || {}
+    }
+    catch (err) {
+      return {}
+    }
+  }
+
+  var load = (url) => {
+    if (st.tree[url] || st.loading[url]) {
+      return
+    }
+    st.loading[url] = true
+    chrome.runtime.sendMessage({message: 'files', url}, (res) => {
+      delete st.loading[url]
+      st.tree[url] = res || {err: chrome.runtime.lastError ? chrome.runtime.lastError.message : 'No response'}
+      m.redraw()
+    })
+  }
+
+  var init = () => {
+    st.current = strip(location.href)
+    var current = dir(location.href)
+    var saved = restore()
+
+    // keep the previously chosen root when the current file lives under it
+    st.root = saved.root && current.indexOf(saved.root) === 0 ? saved.root : current
+    ;(saved.open || []).forEach((url) => st.open[url] = true)
+
+    // open every folder between the root and the current file
+    var path = st.root
+    current.slice(st.root.length).split('/').filter(Boolean).forEach((part) => {
+      path += part + '/'
+      st.open[path] = true
+    })
+
+    save()
+  }
+
+  var events = {
+    up: (e) => {
+      e.preventDefault()
+      if (st.root === 'file:///') {
+        return
+      }
+      st.open[st.root] = true
+      st.root = parent(st.root)
+      save()
+    },
+    toggle: (url) => (e) => {
+      e.preventDefault()
+      st.open[url] = !st.open[url]
+      save()
+    },
+  }
+
+  var tree = (url) => {
+    load(url)
+    var node = st.tree[url]
+    if (!node) {
+      return m('._info', 'Loading…')
+    }
+    if (node.err) {
+      return m('._info._error', {title: node.err}, 'Cannot read folder')
+    }
+    if (!node.dirs.length && !node.files.length) {
+      return m('._info', 'No markdown files')
+    }
+    return [
+      node.dirs.map((entry) =>
+        m('._dir', {key: entry.url, class: st.open[entry.url] ? '_open' : ''}, [
+          m('a', {href: entry.url, title: entry.name, onclick: events.toggle(entry.url)}, [
+            m('span._caret'),
+            m('span._label', entry.name),
+          ]),
+          st.open[entry.url] ? m('._ul', tree(entry.url)) : null,
+        ])
+      ),
+      node.files.map((entry) =>
+        m('._file', {key: entry.url, class: same(entry.url, st.current) ? '_active' : ''},
+          m('a', {href: entry.url, title: entry.name}, m('span._label', entry.name))
+        )
+      ),
+    ]
+  }
+
+  return {
+    oninit: init,
+    view: () =>
+      m('#_files.tex2jax-ignore', [
+        m('._header', [
+          m('a._up', {
+            href: parent(st.root),
+            title: 'Parent folder',
+            class: st.root === 'file:///' ? '_disabled' : '',
+            onclick: events.up,
+          }, '↑'),
+          m('span._name', {title: st.root}, basename(st.root) || st.root),
+        ]),
+        m('._tree', tree(st.root)),
+      ])
+  }
+})()

--- a/content/index.css
+++ b/content/index.css
@@ -31,7 +31,8 @@ details summary {
   /*hide sidebar*/
   html body._toc-left { padding-left: 0px !important; }
   html body._toc-right { padding-right: 0px !important; }
-  #_toc { display: none; }
+  html body._files-left { padding-left: 0px !important; }
+  #_toc, #_files { display: none; }
   /*fix github themes auto*/
   body._theme-github .markdown-body { border: 0; padding: 20px; }
   body._theme-github-dark .markdown-body { border: 0; padding: 20px; }
@@ -170,6 +171,155 @@ body._toc-right { padding-right: 300px !important; }
 }
 ._color-dark #_toc {
   border-right: 1px solid #30363d;
+}
+body._toc-right #_toc {
+  left: auto; right: 0;
+  border-right: 0 !important;
+  border-left: 1px solid var(--toc-delimiter);
+}
+._color-light._toc-right #_toc {
+  border-left: 1px solid #e1e4e8;
+}
+._color-dark._toc-right #_toc {
+  border-left: 1px solid #30363d;
+}
+
+/*---------------------------------------------------------------------------*/
+/*file explorer*/
+
+@media (prefers-color-scheme: light) {
+  body {
+    --files-hover: rgba(0, 0, 0, 0.05);
+    --files-active: rgba(9, 105, 218, 0.12);
+    --files-muted: #6e7781;
+    --files-text: #24292f;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  body {
+    --files-hover: rgba(255, 255, 255, 0.06);
+    --files-active: rgba(88, 166, 255, 0.18);
+    --files-muted: #8b949e;
+    --files-text: #c9d1d9;
+  }
+}
+._color-light {
+  --files-hover: rgba(0, 0, 0, 0.05);
+  --files-active: rgba(9, 105, 218, 0.12);
+  --files-muted: #6e7781;
+  --files-text: #24292f;
+}
+._color-dark {
+  --files-hover: rgba(255, 255, 255, 0.06);
+  --files-active: rgba(88, 166, 255, 0.18);
+  --files-muted: #8b949e;
+  --files-text: #c9d1d9;
+}
+body._files-left { padding-left: 300px !important; }
+#_files {
+  position: fixed;
+  top: 0; bottom: 0; left: 0;
+  width: 299px;
+  height: 100%;
+  box-sizing: border-box;
+  border-right: 1px solid var(--toc-delimiter);
+  overflow-y: auto;
+  overflow-x: hidden;
+  color: var(--files-text);
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-size: 14px;
+  line-height: 1.5;
+  word-wrap: normal;
+}
+._color-light #_files {
+  border-right: 1px solid #e1e4e8;
+}
+._color-dark #_files {
+  border-right: 1px solid #30363d;
+}
+#_files ._header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 10px 8px !important;
+  border-bottom: 1px solid var(--toc-delimiter);
+  font-weight: 600;
+}
+#_files ._header ._up {
+  flex: none;
+  width: 24px;
+  height: 24px;
+  line-height: 24px !important;
+  text-align: center;
+  border-radius: 4px;
+  border: 0 !important;
+  text-decoration: none !important;
+}
+#_files ._header ._up:hover {
+  background: var(--files-hover);
+}
+#_files ._header ._up._disabled {
+  opacity: 0.35;
+  pointer-events: none;
+}
+#_files ._header ._name {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+#_files ._tree {
+  padding: 8px 0 15px !important;
+}
+#_files ._ul {
+  padding-left: 16px !important;
+  margin: 0 !important;
+}
+#_files ._dir > a,
+#_files ._file > a {
+  display: flex !important;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  color: inherit !important;
+  text-decoration: none !important;
+  white-space: nowrap;
+}
+#_files ._dir > a:hover,
+#_files ._file > a:hover {
+  background: var(--files-hover);
+}
+#_files ._file._active > a {
+  background: var(--files-active);
+  font-weight: 600;
+}
+#_files ._label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#_files ._file ._label {
+  padding-left: 16px;
+}
+#_files ._caret {
+  flex: none;
+  width: 12px;
+  color: var(--files-muted);
+  font-size: 10px;
+}
+#_files ._caret::before {
+  content: '▶';
+  display: inline-block;
+  transition: transform 0.1s;
+}
+#_files ._dir._open > a ._caret::before {
+  transform: rotate(90deg);
+}
+#_files ._info {
+  padding: 3px 10px 3px 26px !important;
+  color: var(--files-muted);
+  font-style: italic;
+  white-space: nowrap;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/content/index.js
+++ b/content/index.js
@@ -192,9 +192,19 @@ function mount () {
           ))
         }
 
+        var explorer = state.content.files && location.protocol === 'file:'
+
+        if (explorer) {
+          dom.push(m(files))
+          $('body').classList.add('_files-left')
+        }
+
         if (state.content.toc) {
           dom.push(m('#_toc.tex2jax-ignore', m.trust(state.toc)))
-          state.raw ? $('body').classList.remove('_toc-left') : $('body').classList.add('_toc-left')
+          $('body').classList.remove('_toc-left', '_toc-right')
+          if (!state.raw) {
+            $('body').classList.add(explorer ? '_toc-right' : '_toc-left')
+          }
         }
 
         if (state.theme === 'custom') {

--- a/content/themes.css
+++ b/content/themes.css
@@ -25,6 +25,9 @@
 /*toc*/
 
 /*github*/
+._theme-github #_files {
+  background-color: var(--color-canvas-default);
+}
 ._theme-github #_toc { /*.markdown-body {*/
   background-color: var(--color-canvas-default);
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
@@ -42,6 +45,9 @@
 }
 
 /*github-dark*/
+._theme-github-dark #_files {
+  background-color: #0d1117;
+}
 ._theme-github-dark #_toc { /*.markdown-body {*/
   background-color: #0d1117;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -43,6 +43,7 @@
       "/background/messages.js",
       "/background/mathjax.js",
       "/background/xhr.js",
+      "/background/files.js",
       "/background/icon.js",
 
       "/background/index.js"

--- a/popup/index.js
+++ b/popup/index.js
@@ -62,6 +62,7 @@ var Popup = () => {
         autoreload: 'Auto reload on file change',
         emoji: 'Convert emoji :shortnames: into EmojiOne images',
         toc: 'Generate Table of Contents',
+        files: 'File explorer for local files',
         mathjax: 'Render MathJax formulas',
         mermaid: 'Mermaid diagrams',
         syntax: 'Syntax highlighting for fenced code blocks',


### PR DESCRIPTION
## Summary

Adds a **File explorer for local files** content option (off by default). When enabled on a `file:///` page, a sidebar on the left shows the current folder as a tree:

- Subfolders and markdown files of the current file's folder, sorted naturally; dotfiles hidden. Files are filtered with the same extension regex used for `file://` detection.
- Folders expand lazily on click. The current file is highlighted. The header's ↑ button re-roots to the parent folder.
- Root and expanded folders persist in `localStorage`, so moving between files keeps your place; folders between the root and the current file auto-expand.
- When the ToC is also enabled it moves to the right side (uses the existing `_toc-right` class). Both sidebars are hidden when printing.

## Implementation

- `background/files.js` fetches the browser's directory listing via `xhr.raw` and parses both Chrome's `addRow(...)` format and Firefox's `<a class="dir|file">` table format.
- `content/files.js` is the Mithril sidebar component, injected before `content/index.js` when the option is on.
- New `content.files` default plus a v5.3 → v5.4 migration in `storage.js`; new `files` message in `messages.js`; popup description; README feature bullet.
- Theme-aware colors in `content/index.css`, plus github/github-dark background in `content/themes.css`.

Version bump and changelog are intentionally left out of this PR.

## Testing

- Parser checked in Node against both listing formats, including quoted and percent-encoded names.
- Sidebar tested in Chrome with the unpacked extension on local `.md` files: expand, up-navigation, active highlight, persistence across navigation, empty and error states, light and dark themes, ToC on the right.
- Firefox listing format is based on Firefox's known markup, not tested live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)